### PR TITLE
Fix duplicated flake8 options

### DIFF
--- a/flake8.config
+++ b/flake8.config
@@ -68,8 +68,6 @@ per-file-ignores =
     # Scripts
     scripts/*:T201,E501
 
-# Import order style
-import-order-style = google
 
 # Application import names
 application-import-names = genesis_backend
@@ -97,8 +95,6 @@ select =
     C,   # mccabe complexity
     T,   # flake8-print
 
-# Inline ignore format
-inline-quotes = double
 
 # Statistics
 statistics = True


### PR DESCRIPTION
## Summary
- remove duplicate `import-order-style` option
- remove duplicate `inline-quotes` option

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68785d6645dc8325b487dcee859f86a5